### PR TITLE
feat: 커스텀 스크롤이 네이티브 스크롤과 함께 움직이지 않는 이슈 해결

### DIFF
--- a/src/components/body/BodyMainPanel.tsx
+++ b/src/components/body/BodyMainPanel.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
+import { LayoutContextActionTypes } from "../../@interface";
 import { useDatagridContext } from "../../context/DatagridContext";
-import { useDatagridLayoutContext } from "../../context/DatagridLayoutContext";
+import {
+  useDatagridLayoutContext,
+  useDatagridLayoutDispatch,
+} from "../../context/DatagridLayoutContext";
 import BodyTable from "./BodyTable";
 
 interface IProps {
@@ -17,6 +21,7 @@ const BodyMainPanel: React.FC<IProps> = ({
 }) => {
   const context = useDatagridContext();
   const layoutContext = useDatagridLayoutContext();
+  const layoutDispatch = useDatagridLayoutDispatch();
   const { _bodyWidth = 1, _bodyHeight = 1 } = layoutContext;
   const { dataLength, bodyRowHeight = 20 } = context;
 
@@ -53,12 +58,24 @@ const BodyMainPanel: React.FC<IProps> = ({
     [styleTop, styleLeft, dataLength, bodyRowHeight, bodyContentWidth]
   );
 
+  const onScroll: React.EventHandler<any> = (evt) => {
+    const scrollTop = evt.target?.scrollTop;
+    layoutDispatch({
+      type: LayoutContextActionTypes.SET_SCROLL_TOP,
+      scrollTop,
+    });
+  };
+
   if (!context._colGroup || context._colGroup.length < 1) {
     return null;
   }
 
   return (
-    <div className="ac-datagrid--body--main__panel" style={containerStyle}>
+    <div
+      className="ac-datagrid--body--main__panel"
+      style={containerStyle}
+      onScroll={onScroll}
+    >
       <div data-panel={"scroll-content"} style={contentContainerStyle}>
         <BodyTable
           columns={context._colGroup}

--- a/src/components/body/BodyMainPanel.tsx
+++ b/src/components/body/BodyMainPanel.tsx
@@ -60,9 +60,11 @@ const BodyMainPanel: React.FC<IProps> = ({
 
   const onScroll: React.EventHandler<any> = (evt) => {
     const scrollTop = evt.target?.scrollTop;
+    const scrollLeft = evt.target?.scrollLeft;
     layoutDispatch({
-      type: LayoutContextActionTypes.SET_SCROLL_TOP,
+      type: LayoutContextActionTypes.SET_SCROLL,
       scrollTop,
+      scrollLeft,
     });
   };
 

--- a/src/components/body/BodyMainPanel.tsx
+++ b/src/components/body/BodyMainPanel.tsx
@@ -20,6 +20,7 @@ const BodyMainPanel: React.FC<IProps> = ({
   styleTop,
   styleLeft,
 }) => {
+  const scrollContentRef = React.useRef<HTMLDivElement>(null);
   const context = useDatagridContext();
   const layoutContext = useDatagridLayoutContext();
   const layoutDispatch = useDatagridLayoutDispatch();
@@ -59,9 +60,9 @@ const BodyMainPanel: React.FC<IProps> = ({
     [styleTop, styleLeft, dataLength, bodyRowHeight, bodyContentWidth]
   );
 
-  const onScroll: React.EventHandler<any> = throttle((evt) => {
-    const scrollTop = evt.target?.scrollTop;
-    const scrollLeft = evt.target?.scrollLeft;
+  const onScroll: React.EventHandler<any> = throttle(() => {
+    const scrollTop = scrollContentRef.current?.scrollTop || 0;
+    const scrollLeft = scrollContentRef.current?.scrollLeft || 0;
     layoutDispatch({
       type: LayoutContextActionTypes.SET_SCROLL,
       scrollTop,
@@ -77,6 +78,7 @@ const BodyMainPanel: React.FC<IProps> = ({
     <div
       className="ac-datagrid--body--main__panel"
       style={containerStyle}
+      ref={scrollContentRef}
       onScroll={onScroll}
     >
       <div data-panel={"scroll-content"} style={contentContainerStyle}>

--- a/src/components/body/BodyMainPanel.tsx
+++ b/src/components/body/BodyMainPanel.tsx
@@ -5,6 +5,7 @@ import {
   useDatagridLayoutContext,
   useDatagridLayoutDispatch,
 } from "../../context/DatagridLayoutContext";
+import throttle from "lodash.throttle";
 import BodyTable from "./BodyTable";
 
 interface IProps {
@@ -58,7 +59,7 @@ const BodyMainPanel: React.FC<IProps> = ({
     [styleTop, styleLeft, dataLength, bodyRowHeight, bodyContentWidth]
   );
 
-  const onScroll: React.EventHandler<any> = (evt) => {
+  const onScroll: React.EventHandler<any> = throttle((evt) => {
     const scrollTop = evt.target?.scrollTop;
     const scrollLeft = evt.target?.scrollLeft;
     layoutDispatch({
@@ -66,7 +67,7 @@ const BodyMainPanel: React.FC<IProps> = ({
       scrollTop,
       scrollLeft,
     });
-  };
+  });
 
   if (!context._colGroup || context._colGroup.length < 1) {
     return null;


### PR DESCRIPTION
![3-eac920e539a8](https://user-images.githubusercontent.com/52448114/142764096-d9ee7e2a-6c1a-433c-b931-9df4b7e91bcb.gif)

body main panel 요소에 onScroll 이벤트를 추가하고, 
스크롤 이벤트가 발생할 때 이벤트 객체의 scrollTop, scrollLeft 값을 가져와 
DataGridLayoutContext의 scrollTop, scrollLeft로 설정했습니다. 

그리고 lodash 라이브러리의 throttle 함수를 적용해서 스크롤 이벤트 핸들러 호출 횟수를 줄여봤습니다. 

+)
body main panel과 header left panel의 스크롤 속도에 차이가 있어서인지, 
라인넘버 부분이 조금씩 밀리고 맞지 않는 현상이 있습니다. 