### PR TITLE
bug: aside panel number line style error

### DIFF
--- a/src/style/body.less
+++ b/src/style/body.less
@@ -44,10 +44,13 @@
   overflow: hidden;
   border-right: var(--border);
   text-align: center;
-  background: var(--line-number-bg);
   position: sticky;
   z-index: 2;
   left: 0;
+  td {
+    background: var(--line-number-bg);
+    color: var(--txt-header-color);
+  }
 }
 
 .ac-datagrid--body--main__panel--body__table {


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/26193155/143733869-47785b23-2350-473c-a0c7-72084d303ec9.png)

- `body table`의 색이 `aside panel`에 칠해지는 현상을 수정했습니다.
- `aside panel`과 `body table`이 맞지 않는 현상은 필터링 기능에서 수정됩니다.