### PR TITLE
Bug/#34 When a small amount of data is input, a difference in height between the asid panel and the body table occurs.

### DIFF
--- a/src/components/body/BodyAsidePanel.tsx
+++ b/src/components/body/BodyAsidePanel.tsx
@@ -10,7 +10,6 @@ interface IProps {
 const BodyAsidePanel: React.FC<IProps> = ({ startRowIndex, endRowIndex }) => {
   const context = useDatagridContext();
   const layoutContext = useDatagridLayoutContext();
-  const { _bodyHeight: height } = layoutContext;
 
   const lineNumberStartAt = React.useMemo(
     () => context.lineNumberStartAt || 1,
@@ -18,13 +17,14 @@ const BodyAsidePanel: React.FC<IProps> = ({ startRowIndex, endRowIndex }) => {
   );
 
   const tableStyle = React.useMemo(
-    () => ({ width: layoutContext._lineNumberColumnWidth, height }),
-    [layoutContext._lineNumberColumnWidth, height]
+    () => ({ width: layoutContext._lineNumberColumnWidth }),
+    [layoutContext._lineNumberColumnWidth]
   );
 
-  const rowStyle = React.useMemo(() => ({ height: context.bodyRowHeight }), [
-    context.bodyRowHeight,
-  ]);
+  const rowStyle = React.useMemo(
+    () => ({ height: context.bodyRowHeight }),
+    [context.bodyRowHeight]
+  );
 
   if (!context.enableLineNumber) {
     return null;

--- a/src/components/body/BodyMainPanel.tsx
+++ b/src/components/body/BodyMainPanel.tsx
@@ -27,6 +27,12 @@ const BodyMainPanel: React.FC<IProps> = ({
   const { _bodyWidth = 1, _bodyHeight = 1, _scrollTop } = layoutContext;
   const { dataLength, bodyRowHeight = 20 } = context;
 
+  const isSmallData = React.useMemo(() => {
+    const displayRowCount = Math.floor(_bodyHeight / bodyRowHeight);
+    const startRowIndex = Math.floor(_scrollTop / bodyRowHeight);
+    return startRowIndex + displayRowCount > dataLength;
+  }, [_bodyHeight, bodyRowHeight, dataLength, _scrollTop]);
+
   const lineNumberColumnWidth = React.useMemo(() => {
     return context.enableLineNumber
       ? layoutContext._lineNumberColumnWidth || 50
@@ -127,7 +133,7 @@ const BodyMainPanel: React.FC<IProps> = ({
       <div data-panel={"scroll-content"} style={contentContainerStyle}>
         <BodyAsidePanel
           startRowIndex={startRowIndex}
-          endRowIndex={endRowIndex}
+          endRowIndex={isSmallData ? endRowIndex - 1 : endRowIndex}
           styleTop={0}
         />
         <BodyTable


### PR DESCRIPTION
## Description

적은 양의 데이터가 입력으로 들어올 때,  asid panel과 body table각 행의 높이가 다릅니다.

<img width="508" alt="스크린샷 2021-11-28 오후 5 30 51" src="https://user-images.githubusercontent.com/52450447/143735324-bfee391a-d7a0-49a4-8db1-973ed7f0ba55.png">

### after issue
<img width="502" alt="스크린샷 2021-11-28 오후 5 39 31" src="https://user-images.githubusercontent.com/52450447/143735682-938f7f0f-ba26-4b70-abcf-341142a8aa10.png">

